### PR TITLE
qt: Add missing QPainterPath include

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -7,6 +7,7 @@
 #include <qt/clientmodel.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 


### PR DESCRIPTION
This is needed to compile with Qt 5.15.

Here is the issue reported on bitcoin
https://github.com/bitcoin/bitcoin/issues/19510
