### PR TITLE
Coin control support

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -91,7 +91,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1517356801; // January 31st, 2018
 
         // Deployment of Mimblewimble (LIP-0002 and LIP-0003)
-        consensus.vDeployments[Consensus::DEPLOYMENT_MW].bit = 2; // MW: Figure out bit, nStartTime, and nTimeout
+        consensus.vDeployments[Consensus::DEPLOYMENT_MW].bit = 2; // MW: TODO - Figure out bit, nStartTime, and nTimeout
         consensus.vDeployments[Consensus::DEPLOYMENT_MW].nStartTime = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_MW].nTimeout = 0;// Consensus::BIP9Deployment::NO_TIMEOUT;
 
@@ -213,7 +213,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1517356801; // January 31st, 2018
 
         // Deployment of Mimblewimble (LIP-0002 and LIP-0003)
-        consensus.vDeployments[Consensus::DEPLOYMENT_MW].bit = 2; // MW: Figure out bit, nStartTime, and nTimeout
+        consensus.vDeployments[Consensus::DEPLOYMENT_MW].bit = 2; // MW: TODO - Figure out bit, nStartTime, and nTimeout
         consensus.vDeployments[Consensus::DEPLOYMENT_MW].nStartTime = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_MW].nTimeout = 0; //Consensus::BIP9Deployment::NO_TIMEOUT;
 
@@ -319,7 +319,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // Deployment of Mimblewimble (LIP-0002 and LIP-0003)
-        consensus.vDeployments[Consensus::DEPLOYMENT_MW].bit = 2; // MW: Figure out bit, nStartTime, and nTimeout
+        consensus.vDeployments[Consensus::DEPLOYMENT_MW].bit = 2; // MW: TODO - Figure out bit, nStartTime, and nTimeout
         consensus.vDeployments[Consensus::DEPLOYMENT_MW].nStartTime = 1601450001; // September 30, 2020
         consensus.vDeployments[Consensus::DEPLOYMENT_MW].nTimeout = 1632960000;   // Spetember 30, 2021
         
@@ -400,7 +400,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // Deployment of Mimblewimble (LIP-0002 and LIP-0003)
-        consensus.vDeployments[Consensus::DEPLOYMENT_MW].bit = 2; // MW: Figure out bit, nStartTime, and nTimeout
+        consensus.vDeployments[Consensus::DEPLOYMENT_MW].bit = 2; // MW: TODO - Figure out bit, nStartTime, and nTimeout
         consensus.vDeployments[Consensus::DEPLOYMENT_MW].nStartTime = 1601450001; // September 30, 2020
         consensus.vDeployments[Consensus::DEPLOYMENT_MW].nTimeout = 1632960000;   // Spetember 30, 2021
 

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -24,7 +24,7 @@ class UniValue;
 CScript ParseScript(const std::string& s);
 std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
 NODISCARD bool DecodeHexTx(CMutableTransaction& tx, const std::string& hex_tx, bool try_no_witness = false, bool try_witness = true);
-NODISCARD bool DecodeHexBlk(CBlock&, const std::string& strHexBlk, const bool try_no_mw = false, const bool try_mw = true);
+NODISCARD bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
 bool DecodeHexBlockHeader(CBlockHeader&, const std::string& hex_header);
 
 /**

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -160,32 +160,19 @@ bool DecodeHexBlockHeader(CBlockHeader& header, const std::string& hex_header)
     return true;
 }
 
-// MW: Check consumers to determine values of try_no_mw & try_mw
-bool DecodeHexBlk(CBlock& block, const std::string& strHexBlk, const bool try_no_mw, const bool try_mw)
+bool DecodeHexBlk(CBlock& block, const std::string& strHexBlk)
 {
     if (!IsHex(strHexBlk))
         return false;
 
     std::vector<unsigned char> blockData(ParseHex(strHexBlk));
 
-    if (try_no_mw) {
-        CDataStream ssBlock(blockData, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_NO_MIMBLEWIMBLE);
-        try {
-            ssBlock >> block;
-            return true;
-        } catch (const std::exception&) {
-            // Fall through.
-        }
-    }
-
-    if (try_mw) {
-        CDataStream ssBlock(blockData, SER_NETWORK, PROTOCOL_VERSION);
-        try {
-            ssBlock >> block;
-            return true;
-        } catch (const std::exception&) {
-            // Fall through.
-        }
+    CDataStream ssBlock(blockData, SER_NETWORK, PROTOCOL_VERSION);
+    try {
+        ssBlock >> block;
+        return true;
+    } catch (const std::exception&) {
+        // Fall through.
     }
 
     return false;

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -177,6 +177,10 @@ public:
     bool getPrivKey(const CKeyID& address, CKey& key) override { return m_wallet->GetKey(address, key); }
     bool isSpendable(const CTxDestination& dest) override { return IsMine(*m_wallet, dest) & ISMINE_SPENDABLE; }
     bool haveWatchOnly() override { return m_wallet->HaveWatchOnly(); };
+    bool getMWEBAddress(libmw::MWEBAddress& address) override
+    {
+        return m_wallet->GetMWEBAddress(address);
+    }
     bool setAddressBook(const CTxDestination& dest, const std::string& name, const std::string& purpose) override
     {
         return m_wallet->SetAddressBook(dest, name, purpose);

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -10,6 +10,7 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
+#include <key_io.h>
 #include <net.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
@@ -126,10 +127,24 @@ WalletTxOut MakeWalletTxOut(interfaces::Chain::Lock& locked_chain,
     int depth) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     WalletTxOut result;
-    result.txout = wtx.tx->vout[n];
+    result.address = wtx.tx->vout[n].scriptPubKey;
+    result.output_index = COutPoint(wtx.GetHash(), n);
+    result.nValue = wtx.tx->vout[n].nValue;
     result.time = wtx.GetTxTime();
     result.depth_in_main_chain = depth;
     result.is_spent = wallet.IsSpent(locked_chain, wtx.GetHash(), n);
+    return result;
+}
+
+WalletTxOut MakeWalletTxOut(const COutputCoin& coin) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    WalletTxOut result;
+    result.address = coin.GetAddress();
+    result.output_index = coin.GetIndex();
+    result.nValue = coin.GetValue();
+    result.time = coin.GetTime();
+    result.depth_in_main_chain = coin.GetDepth();
+    result.is_spent = false;
     return result;
 }
 
@@ -216,25 +231,30 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->GetDestValues(prefix);
     }
-    void lockCoin(const COutPoint& output) override
+    libmw::Coin findCoin(const libmw::Commitment& output_commit) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->GetCoin(output_commit);
+    }
+    void lockCoin(const OutputIndex& output) override
     {
         auto locked_chain = m_wallet->chain().lock();
         LOCK(m_wallet->cs_wallet);
         return m_wallet->LockCoin(output);
     }
-    void unlockCoin(const COutPoint& output) override
+    void unlockCoin(const OutputIndex& output) override
     {
         auto locked_chain = m_wallet->chain().lock();
         LOCK(m_wallet->cs_wallet);
         return m_wallet->UnlockCoin(output);
     }
-    bool isLockedCoin(const COutPoint& output) override
+    bool isLockedCoin(const OutputIndex& output) override
     {
         auto locked_chain = m_wallet->chain().lock();
         LOCK(m_wallet->cs_wallet);
-        return m_wallet->IsLockedCoin(output.hash, output.n);
+        return m_wallet->IsLockedCoin(output);
     }
-    void listLockedCoins(std::vector<COutPoint>& outputs) override
+    void listLockedCoins(std::vector<OutputIndex>& outputs) override
     {
         auto locked_chain = m_wallet->chain().lock();
         LOCK(m_wallet->cs_wallet);
@@ -439,13 +459,12 @@ public:
         for (const auto& entry : m_wallet->ListCoins(*locked_chain)) {
             auto& group = result[entry.first];
             for (const auto& coin : entry.second) {
-                group.emplace_back(COutPoint(coin.tx->GetHash(), coin.i),
-                    MakeWalletTxOut(*locked_chain, *m_wallet, *coin.tx, coin.i, coin.nDepth));
+                group.emplace_back(MakeWalletTxOut(coin));
             }
         }
         return result;
     }
-    std::vector<WalletTxOut> getCoins(const std::vector<COutPoint>& outputs) override
+    std::vector<WalletTxOut> getCoins(const std::vector<OutputIndex>& outputs) override
     {
         auto locked_chain = m_wallet->chain().lock();
         LOCK(m_wallet->cs_wallet);
@@ -453,12 +472,17 @@ public:
         result.reserve(outputs.size());
         for (const auto& output : outputs) {
             result.emplace_back();
-            auto it = m_wallet->mapWallet.find(output.hash);
-            if (it != m_wallet->mapWallet.end()) {
-                int depth = it->second.GetDepthInMainChain(*locked_chain);
-                if (depth >= 0) {
-                    result.back() = MakeWalletTxOut(*locked_chain, *m_wallet, it->second, output.n, depth);
+            if (output.which() == 0) {
+                const COutPoint& outpoint = boost::get<COutPoint>(output);
+                auto it = m_wallet->mapWallet.find(outpoint.hash);
+                if (it != m_wallet->mapWallet.end()) {
+                    int depth = it->second.GetDepthInMainChain(*locked_chain);
+                    if (depth >= 0) {
+                        result.back() = MakeWalletTxOut(*locked_chain, *m_wallet, it->second, outpoint.n, depth);
+                    }
                 }
+            } else {
+                // MW: TODO - Handle libmw::Commitment's
             }
         }
         return result;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -91,6 +91,9 @@ public:
     //! Return whether wallet has watch only keys.
     virtual bool haveWatchOnly() = 0;
 
+    //! Generates a new MWEB receive address.
+    virtual bool getMWEBAddress(libmw::MWEBAddress& address) = 0;
+
     //! Add or update address.
     virtual bool setAddressBook(const CTxDestination& dest, const std::string& name, const std::string& purpose) = 0;
 
@@ -312,7 +315,7 @@ public:
 //! Information about one wallet address.
 struct WalletAddress
 {
-    CTxDestination dest; // MW: TODO - Support StealthAddresses too
+    CTxDestination dest;
     isminetype is_mine;
     std::string name;
     std::string purpose;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -119,17 +119,19 @@ public:
     //! Get dest values with prefix.
     virtual std::vector<std::string> getDestValues(const std::string& prefix) = 0;
 
+    virtual libmw::Coin findCoin(const libmw::Commitment& output_commit) = 0;
+
     //! Lock coin.
-    virtual void lockCoin(const COutPoint& output) = 0;
+    virtual void lockCoin(const OutputIndex& output) = 0;
 
     //! Unlock coin.
-    virtual void unlockCoin(const COutPoint& output) = 0;
+    virtual void unlockCoin(const OutputIndex& output) = 0;
 
     //! Return whether coin is locked.
-    virtual bool isLockedCoin(const COutPoint& output) = 0;
+    virtual bool isLockedCoin(const OutputIndex& output) = 0;
 
     //! List locked coins.
-    virtual void listLockedCoins(std::vector<COutPoint>& outputs) = 0;
+    virtual void listLockedCoins(std::vector<OutputIndex>& outputs) = 0;
 
     //! Create transaction.
     virtual std::unique_ptr<PendingWalletTx> createTransaction(const std::vector<CRecipient>& recipients,
@@ -217,11 +219,11 @@ public:
 
     //! Return AvailableCoins + LockedCoins grouped by wallet address.
     //! (put change in one group with wallet address)
-    using CoinsList = std::map<CTxDestination, std::vector<std::tuple<COutPoint, WalletTxOut>>>;
+    using CoinsList = std::map<boost::variant<CTxDestination, libmw::MWEBAddress>, std::vector<WalletTxOut>>;
     virtual CoinsList listCoins() = 0;
 
     //! Return wallet transaction output information.
-    virtual std::vector<WalletTxOut> getCoins(const std::vector<COutPoint>& outputs) = 0;
+    virtual std::vector<WalletTxOut> getCoins(const std::vector<OutputIndex>& outputs) = 0;
 
     //! Get required fee.
     virtual CAmount getRequiredFee(unsigned int tx_bytes) = 0;
@@ -310,7 +312,7 @@ public:
 //! Information about one wallet address.
 struct WalletAddress
 {
-    CTxDestination dest;
+    CTxDestination dest; // MW: TODO - Support StealthAddresses too
     isminetype is_mine;
     std::string name;
     std::string purpose;
@@ -384,7 +386,9 @@ struct WalletTxStatus
 //! Wallet transaction output.
 struct WalletTxOut
 {
-    CTxOut txout;
+    boost::variant<CScript, libmw::MWEBAddress> address;
+    OutputIndex output_index;
+    CAmount nValue;
     int64_t time;
     int depth_in_main_chain = -1;
     bool is_spent = false;

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -67,11 +67,21 @@ public:
         return bech32::Encode(m_params.Bech32HRP(), data);
     }
 
+    std::string operator()(const MWEBAddress& id) const
+    {
+        return id.address;
+    }
+
     std::string operator()(const CNoDestination& no) const { return {}; }
 };
 
 CTxDestination DecodeDestination(const std::string& str, const CChainParams& params)
 {
+    if (str.size() > 5 && str.substr(0, 5) == "mweb1") {
+        // MW: TODO - Validate the address
+        return MWEBAddress(str);
+    }
+
     std::vector<unsigned char> data;
     uint160 hash;
     if (DecodeBase58Check(str, data)) {

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -235,7 +235,7 @@ bool IsValidDestinationString(const std::string& str)
     return IsValidDestinationString(str, Params());
 }
 
-bool IsValidMWEBDestinationString(const std::string& str)
+bool IsValidMWEBDestinationString(const std::string& str) // MW: TODO - Belongs in libmw
 {
     std::size_t pos = str.find(':');
     if (pos == std::string::npos) return false;

--- a/src/mimblewimble/models.h
+++ b/src/mimblewimble/models.h
@@ -69,8 +69,6 @@ struct CMWTx
 
     libmw::TxRef m_transaction;
 
-    // MW: TODO - Cache kernel hashes and input/output commits
-
     CMWTx() = default;
     CMWTx(const libmw::TxRef& tx)
         : m_transaction(tx) { }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -540,7 +540,7 @@ bool BlockAssembler::AddMWEBTransaction(CTxMemPool::txiter iter)
     //
     // Add transaction to MWEB
     //
-    if (libmw::miner::AddTransaction(mweb_builder, pTx->m_mwtx.m_transaction, pegins) != 0) {
+    if (!libmw::miner::AddTransaction(mweb_builder, pTx->m_mwtx.m_transaction, pegins)) {
         LogPrintf("Failed to add MWEB transaction\n");
         return false;
     }

--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -16,6 +16,7 @@
 static const std::string OUTPUT_TYPE_STRING_LEGACY = "legacy";
 static const std::string OUTPUT_TYPE_STRING_P2SH_SEGWIT = "p2sh-segwit";
 static const std::string OUTPUT_TYPE_STRING_BECH32 = "bech32";
+static const std::string OUTPUT_TYPE_STRING_MWEB = "mweb";
 
 bool ParseOutputType(const std::string& type, OutputType& output_type)
 {
@@ -28,6 +29,9 @@ bool ParseOutputType(const std::string& type, OutputType& output_type)
     } else if (type == OUTPUT_TYPE_STRING_BECH32) {
         output_type = OutputType::BECH32;
         return true;
+    } else if (type == OUTPUT_TYPE_STRING_MWEB) {
+        output_type = OutputType::MWEB;
+        return true;
     }
     return false;
 }
@@ -38,6 +42,7 @@ const std::string& FormatOutputType(OutputType type)
     case OutputType::LEGACY: return OUTPUT_TYPE_STRING_LEGACY;
     case OutputType::P2SH_SEGWIT: return OUTPUT_TYPE_STRING_P2SH_SEGWIT;
     case OutputType::BECH32: return OUTPUT_TYPE_STRING_BECH32;
+    case OutputType::MWEB: return OUTPUT_TYPE_STRING_MWEB;
     default: assert(false);
     }
 }

--- a/src/outputtype.h
+++ b/src/outputtype.h
@@ -25,6 +25,7 @@ enum class OutputType {
      * CWallet::TransactionChangeType for details).
      */
     CHANGE_AUTO,
+    MWEB
 };
 
 NODISCARD bool ParseOutputType(const std::string& str, OutputType& output_type);

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -336,7 +336,7 @@ void AddressTableModel::updateEntry(const QString &address,
     priv->updateEntry(address, label, isMine, purpose, status);
 }
 
-QString AddressTableModel::addRow(const QString &type, const QString &label, const QString &address, const OutputType address_type, bool mweb)
+QString AddressTableModel::addRow(const QString &type, const QString &label, const QString &address, const OutputType address_type)
 {
     std::string strLabel = label.toStdString();
     std::string strAddress = address.toStdString();
@@ -360,9 +360,13 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
             }
         }
     }
-    else if(type == Receive && mweb)
+    else if(type == Receive && address_type == OutputType::MWEB)
     {
-        strAddress = libmw::wallet::GetAddress(walletModel->wallet().GetMWWallet());
+        libmw::MWEBAddress address;
+        if (!walletModel->wallet().getMWEBAddress(strAddress)) {
+            editStatus = KEY_GENERATION_FAILURE;
+            return QString();
+        }
     }
     else if(type == Receive)
     {

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -65,7 +65,7 @@ public:
     /* Add an address to the model.
        Returns the added address on success, and an empty string otherwise.
      */
-    QString addRow(const QString &type, const QString &label, const QString &address, const OutputType address_type, bool mweb = false);
+    QString addRow(const QString &type, const QString &label, const QString &address, const OutputType address_type);
 
     /** Look up label for address in address book, if not found return empty string. */
     QString labelForAddress(const QString &address) const;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -753,7 +753,6 @@ void CoinControlDialog::updateView()
                 // vout index
                 itemOutput->setData(COLUMN_ADDRESS, VOutRole, outpoint.n);
             } else {
-                // MW: TODO - Set COLUMN_ADDRESS fields for libmw::Commitments
                 const libmw::Commitment& output_commit = boost::get<libmw::Commitment>(out.output_index);
                 itemOutput->setData(COLUMN_ADDRESS, CommitmentRole, QString::fromStdString(HexStr(output_commit)));
             }

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_COINCONTROLDIALOG_H
 
 #include <amount.h>
+#include <wallet/coinselection.h>
 
 #include <QAbstractButton>
 #include <QAction>
@@ -69,6 +70,12 @@ private:
 
     const PlatformStyle *platformStyle;
 
+    CInputCoin BuildInputCoin(QTreeWidgetItem* item);
+    OutputIndex BuildOutputIndex(QTreeWidgetItem* item);
+
+    bool IsMWEB(QTreeWidgetItem* item);
+    bool IsCanonical(QTreeWidgetItem* item);
+
     void sortView(int, Qt::SortOrder);
     void updateView();
 
@@ -85,7 +92,9 @@ private:
     enum
     {
         TxHashRole = Qt::UserRole,
-        VOutRole
+        VOutRole,
+        PubKeyRole,
+        CommitmentRole
     };
 
     friend class CCoinControlWidgetItem;

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -153,19 +153,17 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     QString label = ui->reqLabel->text();
     /* Generate new receiving address */
     OutputType address_type;
-    bool mweb = false;
     if (ui->useBech32->isChecked()) {
         address_type = OutputType::BECH32;
     } else if (ui->useMWEB->isChecked()) {
-        address_type = OutputType::BECH32;
-        mweb = true;
+        address_type = OutputType::MWEB;
     } else {
         address_type = model->wallet().getDefaultAddressType();
         if (address_type == OutputType::BECH32) {
             address_type = OutputType::P2SH_SEGWIT;
         }
     }
-    address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "", address_type, mweb);
+    address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "", address_type);
     SendCoinsRecipient info(address, label,
         ui->reqAmount->value(), ui->reqMessage->text());
     ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -929,7 +929,7 @@ void SendCoinsDialog::mwebPegInButtonClicked(bool checked)
 
     SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(0)->widget());
     if (checked) {
-        entry->setPegInAddress(libmw::wallet::GetAddress(model->wallet().GetMWWallet()));
+        entry->setPegInAddress(libmw::wallet::GetAddress(model->wallet().GetMWWallet(), libmw::PEGIN_INDEX));
     } else {
         entry->setPegInAddress("");
     }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -191,7 +191,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                 auto commitment = std::vector<uint8_t>(pegin_tx.second.commitment.cbegin(), pegin_tx.second.commitment.cend());
                 transaction.setMapValue("commitment", HexStr(commitment, false));
                 // MW: TODO - support pegging-in to someone else's address
-                transaction.setMapValue("mweb_recipient", libmw::wallet::GetAddress(m_wallet->GetMWWallet()));
+                transaction.setMapValue("mweb_recipient", libmw::wallet::GetAddress(m_wallet->GetMWWallet(), libmw::PEGIN_INDEX));
                 transaction.setMapValue("mweb_credit", std::to_string(rcp.amount));
                 scriptPubKey << CScript::EncodeOP_N(Consensus::Mimblewimble::WITNESS_VERSION);
                 scriptPubKey << commitment;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -242,6 +242,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
 
         auto& newTx = transaction.getWtx();
         if (pegOut || mwebSend) {
+            // MW: TODO - Support CoinControl
             CAmount feeRate = 100'000;
             if (coinControl.m_feerate) {
                 feeRate = coinControl.m_feerate->GetFeePerK();

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -135,6 +135,16 @@ public:
         obj.pushKV("witness_program", HexStr(id.program, id.program + id.length));
         return obj;
     }
+
+    UniValue operator()(const MWEBAddress& id) const
+    {
+        UniValue obj(UniValue::VOBJ);
+        obj.pushKV("isscript", false);
+        obj.pushKV("iswitness", false);
+        obj.pushKV("ismweb", true);
+        obj.pushKV("mweb_address", id.address);
+        return obj;
+    }
 };
 
 UniValue DescribeAddress(const CTxDestination& dest)

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -202,7 +202,8 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
         addressRet = unk;
         return true;
     } else if (whichType == TX_WITNESS_MW_PEGIN) {
-        // MW: Should we return the kernel address?
+        // MW: TODO - I have no idea how to handle this. Looking up the matching peg-in output would be too slow.
+        return false;
     }
     // Multisig txns have more than one address...
     return false;
@@ -293,6 +294,12 @@ public:
         script->clear();
         *script << CScript::EncodeOP_N(id.version) << std::vector<unsigned char>(id.program, id.program + id.length);
         return true;
+    }
+
+    bool operator()(const MWEBAddress& id) const
+    {
+        script->clear();
+        return false;
     }
 };
 } // namespace

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -112,6 +112,26 @@ struct WitnessUnknown
     }
 };
 
+struct MWEBAddress
+{
+    MWEBAddress(const libmw::MWEBAddress& address_)
+        : address(address_) { }
+
+    libmw::MWEBAddress address;
+
+    friend bool operator==(const MWEBAddress& a1, const MWEBAddress& a2)
+    {
+        return a1.address == a2.address;
+    }
+
+    friend bool operator<(const MWEBAddress& a1, const MWEBAddress& a2)
+    {
+        if (a1.address.size() < a2.address.size()) return true;
+        if (a2.address.size() > a1.address.size()) return false;
+        return std::lexicographical_compare(a1.address.begin(), a1.address.end(), a2.address.begin(), a2.address.end());
+    }
+};
+
 /**
  * A txout script template with a specific destination. It is either:
  *  * CNoDestination: no destination set
@@ -120,9 +140,10 @@ struct WitnessUnknown
  *  * WitnessV0ScriptHash: TX_WITNESS_V0_SCRIPTHASH destination (P2WSH)
  *  * WitnessV0KeyHash: TX_WITNESS_V0_KEYHASH destination (P2WPKH)
  *  * WitnessUnknown: TX_WITNESS_UNKNOWN destination (P2W???)
+ *  * MWEBAddress: MWEB address destination
  *  A CTxDestination is the internal data type encoded in a bitcoin address
  */
-typedef boost::variant<CNoDestination, CKeyID, CScriptID, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown> CTxDestination;
+typedef boost::variant<CNoDestination, CKeyID, CScriptID, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown, MWEBAddress> CTxDestination;
 
 /** Check whether a CTxDestination is a CNoDestination. */
 bool IsValidDestination(const CTxDestination& dest);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -775,14 +775,6 @@ class MockMWWallet : public libmw::IWallet
 public:
     MockMWWallet() : m_bip32_index(1) { }
 
-    libmw::PrivateKey GenerateNewHDKey() final
-    {
-        libmw::PrivateKey privateKey;
-        GetRandBytes(privateKey.keyBytes.data(), 32);
-        privateKey.bip32Path = "m/0/0/" + std::to_string(m_bip32_index++);
-        return privateKey;
-    }
-
     libmw::PrivateKey GetHDKey(const std::string& bip32Path) const final
     {
         libmw::PrivateKey privateKey;

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -49,17 +49,17 @@ public:
         return (setSelected.size() > 0);
     }
 
-    bool IsSelected(const COutPoint& output) const
+    bool IsSelected(const OutputIndex& output) const
     {
         return (setSelected.count(output) > 0);
     }
 
-    void Select(const COutPoint& output)
+    void Select(const OutputIndex& output)
     {
         setSelected.insert(output);
     }
 
-    void UnSelect(const COutPoint& output)
+    void UnSelect(const OutputIndex& output)
     {
         setSelected.erase(output);
     }
@@ -69,13 +69,13 @@ public:
         setSelected.clear();
     }
 
-    void ListSelected(std::vector<COutPoint>& vOutpoints) const
+    void ListSelected(std::vector<OutputIndex>& vOutpoints) const
     {
         vOutpoints.assign(setSelected.begin(), setSelected.end());
     }
 
 private:
-    std::set<COutPoint> setSelected;
+    std::set<OutputIndex> setSelected;
 };
 
 #endif // BITCOIN_WALLET_COINCONTROL_H

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -34,6 +34,14 @@ public:
         m_input_bytes = input_bytes;
     }
 
+    CInputCoin(const uint256& tx_hash, uint32_t i, const CAmount& nValue, const CScript& scriptPubKey)
+    {
+        outpoint = COutPoint(tx_hash, i);
+        txout = CTxOut(nValue, scriptPubKey);
+        effective_value = nValue;
+        mwCoin = nullptr;
+    }
+
     CInputCoin(const libmw::Coin& coin)
     {
         mwCoin = &coin;

--- a/src/wallet/mwebwallet.h
+++ b/src/wallet/mwebwallet.h
@@ -3,12 +3,14 @@
 #include <libmw/libmw.h>
 #include <util/bip32.h>
 #include <wallet/wallet.h>
+#include <wallet/coincontrol.h>
+#include <map>
 
 class MWWallet : public libmw::IWallet
 {
 public:
-    MWWallet(CWallet* pWallet)
-        : m_pWallet(pWallet), m_pBatch(std::make_unique<WalletBatch>(pWallet->GetDBHandle())) {}
+    MWWallet(CWallet* pWallet, interfaces::Chain* pChain)
+        : m_pWallet(pWallet), m_pChain(pChain) {}
 
     libmw::PrivateKey GenerateNewHDKey() final
     {
@@ -18,7 +20,8 @@ public:
         }
 
         // Generate new HD key
-        CKey key = m_pWallet->GenerateNewKey(*m_pBatch);
+        WalletBatch batch(m_pWallet->GetDBHandle());
+        CKey key = m_pWallet->GenerateNewKey(batch);
 
         // Create libmw::PrivateKey
         libmw::PrivateKey privateKey;
@@ -69,26 +72,47 @@ public:
 
     std::vector<libmw::Coin> ListCoins() const final
     {
+        // MW: TODO - Return the map instead.
         std::vector<libmw::Coin> coins;
-        DBErrors errors = m_pBatch->FindMWCoins(coins);
-        if (errors != DBErrors::LOAD_OK) {
-            throw std::runtime_error(std::string(__func__) + ": FindMWCoins returned a DB error");
-        }
+        std::transform(
+            m_coins.cbegin(), m_coins.cend(),
+            std::back_inserter(coins),
+            [](const auto& entry) { return entry.second; }
+        );
 
         return coins;
     }
 
+    void LoadToWallet(const libmw::Coin& coin)
+    {
+        m_coins[coin.commitment] = coin;
+    }
+
+    libmw::Coin GetCoin(const libmw::Commitment& output_commit) const
+    {
+        auto iter = m_coins.find(output_commit);
+        if (iter != m_coins.end()) {
+            return iter->second;
+        }
+
+        throw std::runtime_error(std::string(__func__) + ": Could not find coin with matching output commit");
+    }
+
     void AddCoins(const std::vector<libmw::Coin>& coins) final
     {
+        WalletBatch batch(m_pWallet->GetDBHandle());
         for (const auto& coin : coins) {
-            m_pBatch->WriteMWCoin(coin);
+            batch.WriteMWCoin(coin);
+            m_coins[coin.commitment] = coin;
         }
     }
 
     void DeleteCoins(const std::vector<libmw::Coin>& coins) final
     {
+        WalletBatch batch(m_pWallet->GetDBHandle());
         for (const auto& coin : coins) {
-            m_pBatch->EraseMWCoin(coin.commitment);
+            batch.EraseMWCoin(coin.commitment);
+            m_coins.erase(coin.commitment);
         }
     }
 
@@ -97,11 +121,11 @@ public:
         const uint64_t amount) const final
     {
         std::vector<COutputCoin> vCoins;
-        std::transform(
-            coins.cbegin(), coins.cend(),
-            std::back_inserter(vCoins),
-            [](const libmw::Coin& coin) { return COutputCoin(coin); }
-        );
+        for (const libmw::Coin& coin : coins) {
+            if (!m_pWallet->IsLockedCoin(coin.commitment)) {
+                vCoins.push_back(m_pWallet->MakeOutputCoin(*m_pChain->lock(), coin));
+            }
+        }
 
         std::set<CInputCoin> setCoins;
         CAmount nValueIn;
@@ -134,5 +158,6 @@ public:
 
 private:
     CWallet* m_pWallet;
-    std::unique_ptr<WalletBatch> m_pBatch;
+    interfaces::Chain* m_pChain;
+    std::map<libmw::Commitment, libmw::Coin> m_coins;
 };

--- a/src/wallet/mwebwallet.h
+++ b/src/wallet/mwebwallet.h
@@ -12,28 +12,6 @@ public:
     MWWallet(CWallet* pWallet, interfaces::Chain* pChain)
         : m_pWallet(pWallet), m_pChain(pChain) {}
 
-    libmw::PrivateKey GenerateNewHDKey() final
-    {
-        // Currently, MWEB only supports HD wallets
-        if (!m_pWallet->IsHDEnabled()) {
-            throw std::runtime_error(std::string(__func__) + ": MWEB only supports HD wallets");
-        }
-
-        // Generate new HD key
-        WalletBatch batch(m_pWallet->GetDBHandle());
-        CKey key = m_pWallet->GenerateNewKey(batch);
-
-        // Create libmw::PrivateKey
-        libmw::PrivateKey privateKey;
-        std::copy(key.begin(), key.end(), privateKey.keyBytes.data());
-
-        auto iter = m_pWallet->mapKeyMetadata.find(key.GetPubKey().GetID());
-        assert(iter != m_pWallet->mapKeyMetadata.end());
-        privateKey.bip32Path = iter->second.hdKeypath;
-
-        return privateKey;
-    }
-
     libmw::PrivateKey GetHDKey(const std::string& bip32Path) const final
     {
         // Currently, MWEB only supports HD wallets

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -393,13 +393,13 @@ BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup)
 
     // Confirm ListCoins initially returns 1 coin grouped under coinbaseKey
     // address.
-    std::map<CTxDestination, std::vector<COutput>> list;
+    std::map<boost::variant<CTxDestination, libmw::MWEBAddress>, std::vector<COutputCoin>> list;
     {
         LOCK2(cs_main, wallet->cs_wallet);
         list = wallet->ListCoins(*m_locked_chain);
     }
     BOOST_CHECK_EQUAL(list.size(), 1U);
-    BOOST_CHECK_EQUAL(boost::get<CKeyID>(list.begin()->first).ToString(), coinbaseAddress);
+    BOOST_CHECK_EQUAL(boost::get<CKeyID>(boost::get<CTxDestination>(list.begin()->first)).ToString(), coinbaseAddress);
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 1U);
 
     // Check initial balance from one mature coinbase transaction.
@@ -415,25 +415,25 @@ BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup)
         list = wallet->ListCoins(*m_locked_chain);
     }
     BOOST_CHECK_EQUAL(list.size(), 1U);
-    BOOST_CHECK_EQUAL(boost::get<CKeyID>(list.begin()->first).ToString(), coinbaseAddress);
+    BOOST_CHECK_EQUAL(boost::get<CKeyID>(boost::get<CTxDestination>(list.begin()->first)).ToString(), coinbaseAddress);
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 2U);
 
     // Lock both coins. Confirm number of available coins drops to 0.
     {
         LOCK2(cs_main, wallet->cs_wallet);
-        std::vector<COutput> available;
+        std::vector<COutputCoin> available;
         wallet->AvailableCoins(*m_locked_chain, available);
         BOOST_CHECK_EQUAL(available.size(), 2U);
     }
     for (const auto& group : list) {
         for (const auto& coin : group.second) {
             LOCK(wallet->cs_wallet);
-            wallet->LockCoin(COutPoint(coin.tx->GetHash(), coin.i));
+            wallet->LockCoin(COutPoint(coin.out->tx->GetHash(), coin.out->i));
         }
     }
     {
         LOCK2(cs_main, wallet->cs_wallet);
-        std::vector<COutput> available;
+        std::vector<COutputCoin> available;
         wallet->AvailableCoins(*m_locked_chain, available);
         BOOST_CHECK_EQUAL(available.size(), 0U);
     }
@@ -444,7 +444,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup)
         list = wallet->ListCoins(*m_locked_chain);
     }
     BOOST_CHECK_EQUAL(list.size(), 1U);
-    BOOST_CHECK_EQUAL(boost::get<CKeyID>(list.begin()->first).ToString(), coinbaseAddress);
+    BOOST_CHECK_EQUAL(boost::get<CKeyID>(boost::get<CTxDestination>(list.begin()->first)).ToString(), coinbaseAddress);
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 2U);
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -104,6 +104,7 @@ class CScript;
 class CTxMemPool;
 class CBlockPolicyEstimator;
 class CWalletTx;
+class MWWallet;
 struct FeeCalculation;
 enum class FeeEstimateMode;
 
@@ -604,30 +605,64 @@ public:
     }
 };
 
+struct MWOutput
+{
+    libmw::Coin coin;
+    int nDepth;
+    int64_t nTime;
+    libmw::MWEBAddress address;
+};
+
 struct COutputCoin
 {
-    const COutput *out;
-    const libmw::Coin *mwCoin;
+    boost::optional<COutput> out;
+    boost::optional<MWOutput> mwCoin;
 
-    COutputCoin(const COutput& out) : out(&out) {}
-    COutputCoin(const libmw::Coin& coin) : mwCoin(&coin) {}
+    COutputCoin(const COutput& out) : out(out) {}
+    COutputCoin(const MWOutput& coin) : mwCoin(coin) {}
 
-    inline bool IsSpendable() const
+    bool IsMWEB() const noexcept { return !!mwCoin; }
+
+    bool IsSpendable() const
     {
-        if (mwCoin) return mwCoin->key && !mwCoin->spent;
+        if (IsMWEB()) return mwCoin->coin.key && !mwCoin->coin.spent && mwCoin->coin.included_block;
         return out->fSpendable;
     }
 
-    inline CAmount GetValue() const
+    boost::variant<CScript, libmw::MWEBAddress> GetAddress() const
     {
-        if (mwCoin) return mwCoin->amount;
+        if (IsMWEB()) return mwCoin->address;
+        return out->tx->tx->vout[out->i].scriptPubKey;
+    }
+
+    CAmount GetValue() const
+    {
+        if (IsMWEB()) return mwCoin->coin.amount;
         return out->tx->tx->vout[out->i].nValue;
     }
 
-    inline CInputCoin GetInputCoin() const
+    int64_t GetTime() const
     {
-        if (mwCoin) return CInputCoin(*mwCoin);
+        if (IsMWEB()) return mwCoin->nTime;
+        return out->tx->GetTxTime();
+    }
+
+    int GetDepth() const
+    {
+        if (IsMWEB()) return mwCoin->nDepth;
+        return out->nDepth;
+    }
+
+    CInputCoin GetInputCoin() const
+    {
+        if (IsMWEB()) return CInputCoin(mwCoin->coin);
         return out->GetInputCoin();
+    }
+
+    OutputIndex GetIndex() const
+    {
+        if (IsMWEB()) return mwCoin->coin.commitment;
+        return COutPoint(out->tx->GetHash(), out->i);
     }
 };
 
@@ -700,9 +735,9 @@ private:
      * detect and report conflicts (double-spends or
      * mutated transactions where the mutant gets mined).
      */
-    typedef std::multimap<COutPoint, uint256> TxSpends;
+    typedef std::multimap<OutputIndex, uint256> TxSpends;
     TxSpends mapTxSpends GUARDED_BY(cs_wallet);
-    void AddToSpends(const COutPoint& outpoint, const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AddToSpends(const OutputIndex& outpoint, const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void AddToSpends(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
@@ -777,6 +812,8 @@ private:
      */
     uint256 m_last_block_processed;
 
+    std::shared_ptr<MWWallet> mweb_wallet;
+
 public:
     /*
      * Main wallet lock.
@@ -834,9 +871,7 @@ public:
     unsigned int nMasterKeyMaxID = 0;
 
     /** Construct wallet with specified name and database implementation. */
-    CWallet(interfaces::Chain& chain, const WalletLocation& location, std::unique_ptr<WalletDatabase> database) : m_chain(chain), m_location(location), database(std::move(database))
-    {
-    }
+    CWallet(interfaces::Chain& chain, const WalletLocation& location, std::unique_ptr<WalletDatabase> database);
 
     ~CWallet()
     {
@@ -856,7 +891,7 @@ public:
 
     std::map<CTxDestination, CAddressBookData> mapAddressBook GUARDED_BY(cs_wallet);
 
-    std::set<COutPoint> setLockedCoins GUARDED_BY(cs_wallet);
+    std::set<OutputIndex> setLockedCoins GUARDED_BY(cs_wallet);
 
     /** Interface for accessing chain state. */
     interfaces::Chain& chain() const { return m_chain; }
@@ -869,12 +904,12 @@ public:
     /**
      * populate vCoins with vector of available COutputs.
      */
-    void AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutputCoin>& vCoins, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.
      */
-    std::map<CTxDestination, std::vector<COutput>> ListCoins(interfaces::Chain::Lock& locked_chain) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    std::map<boost::variant<CTxDestination, libmw::MWEBAddress>, std::vector<COutputCoin>> ListCoins(interfaces::Chain::Lock& locked_chain) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Find non-change parent output.
@@ -893,11 +928,11 @@ public:
     bool IsSpent(interfaces::Chain::Lock& locked_chain, const uint256& hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     std::vector<OutputGroup> GroupOutputs(const std::vector<COutputCoin>& outputs, bool single_coin) const;
 
-    bool IsLockedCoin(uint256 hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    void LockCoin(const COutPoint& output) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    void UnlockCoin(const COutPoint& output) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsLockedCoin(const OutputIndex& output) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void LockCoin(const OutputIndex& output) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void UnlockCoin(const OutputIndex& output) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void UnlockAllCoins() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    void ListLockedCoins(std::vector<COutPoint>& vOutpts) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void ListLockedCoins(std::vector<OutputIndex>& vOutpts) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /*
      * Rescan abort properties
@@ -969,6 +1004,7 @@ public:
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     void LoadToWallet(const CWalletTx& wtxIn) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void LoadToWallet(const libmw::Coin& coin) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
@@ -1273,7 +1309,11 @@ public:
     /** Add a KeyOriginInfo to the wallet */
     bool AddKeyOrigin(const CPubKey& pubkey, const KeyOriginInfo& info);
 
-    libmw::IWallet::Ptr GetMWWallet();
+    libmw::Coin GetCoin(const libmw::Commitment& output_commit) const;
+
+    COutputCoin MakeOutputCoin(interfaces::Chain::Lock& locked_chain, const libmw::Coin& coin) const;
+
+    libmw::IWallet::Ptr GetMWWallet() const;
     libmw::IChain::Ptr GetMWChain();
 };
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -629,6 +629,16 @@ struct COutputCoin
         return out->fSpendable;
     }
 
+    bool GetDestination(CTxDestination& dest) const
+    {
+        if (IsMWEB()) {
+            dest = MWEBAddress(mwCoin->address);
+            return true;
+        } else {
+            return ExtractDestination(out->tx->tx->vout[out->i].scriptPubKey, dest);
+        }
+    }
+
     boost::variant<CScript, libmw::MWEBAddress> GetAddress() const
     {
         if (IsMWEB()) return mwCoin->address;
@@ -1106,6 +1116,7 @@ public:
     void KeepKey(int64_t nIndex);
     void ReturnKey(int64_t nIndex, bool fInternal, const CPubKey& pubkey);
     bool GetKeyFromPool(CPubKey &key, bool internal = false);
+    bool GetMWEBAddress(libmw::MWEBAddress& address);
     int64_t GetOldestKeyPoolTime();
     /**
      * Marks all keys in the keypool up to and including reserve_key as used.

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -61,11 +61,13 @@ class CHDChain
 public:
     uint32_t nExternalChainCounter;
     uint32_t nInternalChainCounter;
+    uint32_t nMWEBIndexCounter;
     CKeyID seed_id; //!< seed hash160
 
     static const int VERSION_HD_BASE        = 1;
     static const int VERSION_HD_CHAIN_SPLIT = 2;
-    static const int CURRENT_VERSION        = VERSION_HD_CHAIN_SPLIT;
+    static const int VERSION_HD_MWEB        = 3;
+    static const int CURRENT_VERSION        = VERSION_HD_MWEB;
     int nVersion;
 
     CHDChain() { SetNull(); }
@@ -78,6 +80,9 @@ public:
         READWRITE(seed_id);
         if (this->nVersion >= VERSION_HD_CHAIN_SPLIT)
             READWRITE(nInternalChainCounter);
+
+        if (this->nVersion >= VERSION_HD_MWEB)
+            READWRITE(nMWEBIndexCounter);
     }
 
     void SetNull()
@@ -85,6 +90,7 @@ public:
         nVersion = CHDChain::CURRENT_VERSION;
         nExternalChainCounter = 0;
         nInternalChainCounter = 0;
+        nMWEBIndexCounter = 0;
         seed_id.SetNull();
     }
 };


### PR DESCRIPTION
We originally tried to separate litecoin & mweb wallet logic as much as possible, but we want to move toward making mweb feel more like just a different address type, which involves sometimes mixing canonical & mweb inputs behind the scenes.

This PR takes a step in that direction by combining the 2 outputs & tx types into common objects (OutputIndex, WalletTxOut, etc.) with a particular focus on the CoinControl UI & logic.